### PR TITLE
Fix invalid f-string in Fellenius tests

### DIFF
--- a/tests/test_fellenius.py
+++ b/tests/test_fellenius.py
@@ -163,7 +163,7 @@ def test_generacion_reporte():
         
         print("✅ Reporte generado correctamente")
         print(f"   Longitud del reporte: {len(reporte)} caracteres")
-        print(f"   Líneas del reporte: {len(reporte.split('\\n'))}")
+        print(f"   Líneas del reporte: {len(reporte.splitlines())}")
         
         # Mostrar parte del reporte
         lineas = reporte.split('\n')


### PR DESCRIPTION
## Summary
- fix f-string that used backslash in `tests/test_fellenius.py`

## Testing
- `pytest tests/test_fellenius.py::test_generacion_reporte -q` *(fails: Factor de seguridad inválido)*

------
https://chatgpt.com/codex/tasks/task_b_6840decf8c8c8320ab7fdad10ce13f04