### PR TITLE
Fix typo in model path

### DIFF
--- a/INSTRUCCIONES_EJECUCION.md
+++ b/INSTRUCCIONES_EJECUCION.md
@@ -34,7 +34,7 @@ python -c "import numpy; print('NumPy OK')"
 
 ### Método 1: Desde PowerShell/CMD
 ```bash
-cd "c:\Seba\Proyectos paralelos\estabilidadad-taludes_model"
+cd "c:\Seba\Proyectos paralelos\estabilidad-taludes_model"
 python gui_app.py
 ```
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ python gui_app.py
 ## Estructura del Proyecto
 
 ```
-estabilidadad-taludes_model/
+estabilidad-taludes_model/
 ├── gui_app.py              # Aplicación principal
 ├── gui_analysis.py         # Funciones wrapper para GUI
 ├── gui_components.py       # Componentes de interfaz


### PR DESCRIPTION
## Summary
- update README and INSTRUCCIONES_EJECUCION to reference `estabilidad-taludes_model`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_b_6840e301b340832091e20f6b7142b824