### PR TITLE
Integrate geometric limits into GUI

### DIFF
--- a/core/circle_constraints.py
+++ b/core/circle_constraints.py
@@ -405,6 +405,19 @@ def aplicar_limites_inteligentes(
     return calculador.calcular_limites_desde_perfil(perfil_terreno)
 
 
+def validar_circulo_geometricamente(
+    circulo: CirculoFalla,
+    limites: LimitesGeometricos,
+    corregir_automaticamente: bool = True,
+) -> ResultadoValidacion:
+    """Valida un círculo usando límites pre-calculados."""
+
+    calculador = CalculadorLimites()
+    return calculador.validar_y_corregir_circulo(
+        circulo, limites, corregir_automaticamente
+    )
+
+
 # Función de conveniencia para validación rápida
 def validar_circulo_con_limites(
     circulo: CirculoFalla,

--- a/gui_app.py
+++ b/gui_app.py
@@ -196,7 +196,10 @@ class SlopeStabilityApp:
             
             # Importar clases y funciones necesarias
             from data.models import generar_perfil_simple, CirculoFalla
-            from core.circle_constraints import CalculadorLimites
+            from core.circle_constraints import (
+                aplicar_limites_inteligentes,
+                validar_circulo_geometricamente,
+            )
             from gui_analysis import analizar_desde_gui
 
             # 1. Generar perfil del talud (similar a show_slope_geometry)
@@ -213,28 +216,32 @@ class SlopeStabilityApp:
                 self.progress_bar.set(0)
                 return
 
-            # 2. Calcular límites geométricos basados en el perfil
-            calculador_limites = CalculadorLimites()
+            # 2. Calcular límites geométricos automáticos basados en el perfil
             try:
-                limites_geometricos = calculador_limites.calcular_limites_desde_perfil(perfil_terreno)
+                limites_geometricos = aplicar_limites_inteligentes(
+                    perfil_terreno, "talud_empinado"
+                )
             except Exception as e:
                 self.update_status(f"Error calculando límites geométricos: {e}")
-                messagebox.showerror("Error Interno", f"No se pudo calcular los límites geométricos: {e}")
+                messagebox.showerror(
+                    "Error Interno",
+                    f"No se pudo calcular los límites geométricos: {e}",
+                )
                 self.analysis_running = False
                 self.progress_bar.set(0)
                 return
 
             # 3. Crear objeto CirculoFalla con parámetros de la GUI
-            circulo_actual = CirculoFalla(xc=params['centro_x'], 
-                                        yc=params['centro_y'], 
+            circulo_actual = CirculoFalla(xc=params['centro_x'],
+                                        yc=params['centro_y'],
                                         radio=params['radio'])
 
             # 4. Validar y corregir el círculo
             self.update_status("Validando geometría del círculo...")
-            resultado_validacion = calculador_limites.validar_y_corregir_circulo(
-                circulo_actual, 
-                limites_geometricos, 
-                corregir_automaticamente=True
+            resultado_validacion = validar_circulo_geometricamente(
+                circulo_actual,
+                limites_geometricos,
+                corregir_automaticamente=True,
             )
 
             if not resultado_validacion.es_valido:

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -1,0 +1,17 @@
+import math
+from core.circle_constraints import aplicar_limites_inteligentes, validar_circulo_geometricamente
+from data.models import CirculoFalla
+
+
+def test_validar_circulo_geometricamente():
+    perfil = [(0, 0), (10, 5), (20, 10)]
+    limites = aplicar_limites_inteligentes(perfil, "talud_empinado")
+    circulo = CirculoFalla(xc=-5.0, yc=-5.0, radio=50.0)
+
+    resultado = validar_circulo_geometricamente(circulo, limites, True)
+
+    assert resultado.circulo_corregido is not None
+    c = resultado.circulo_corregido
+    assert limites.centro_x_min <= c.xc <= limites.centro_x_max
+    assert limites.centro_y_min <= c.yc <= limites.centro_y_max
+    assert limites.radio_min <= c.radio <= limites.radio_max


### PR DESCRIPTION
## Summary
- expose `validar_circulo_geometricamente` helper in `circle_constraints`
- use the helper in `gui_app` instead of manual limit calculations
- add regression test for geometric limit validation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684100b1788483209a2477cca5481381