### PR TITLE
Add tests for Dovela attributes and fix geometry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,12 +1,9 @@
 # Guía para el Agente IA: Estrategia de Pruebas Exhaustiva
 
 ## Objetivo Principal para el Agente IA: Generación y Ejecución de Pruebas
-
 Tu tarea principal es desarrollar y ejecutar un conjunto de pruebas exhaustivas para el proyecto `estabilidad-taludes_model`. El objetivo es asegurar la robustez, precisión y fiabilidad de la aplicación en todas sus facetas, desde la interfaz de usuario hasta los cálculos más complejos del núcleo.
 
-**Necesitamos probar TODO.** No asumas que algo funciona; verifica cada componente, cada función, cada interacción.
-
-A continuación, se presenta una lista conceptual de categorías de pruebas y ejemplos de pruebas individuales. Debes usar estas ideas como base para generar pruebas concretas utilizando `pytest` y otras herramientas de testing adecuadas.
+**Necesitamos probar TODO.** No asumas que algo funciona; verifica cada componente, cada función, cada interacción.  A continuación, se presenta una lista conceptual de categorías de pruebas y ejemplos de pruebas individuales. Debes usar estas ideas como base para generar pruebas concretas utilizando `pytest` y otras herramientas de testing adecuadas.
 
 ---
 
@@ -118,14 +115,11 @@ A continuación, se presenta una lista conceptual de categorías de pruebas y ej
 6.  **Automatización:** Las pruebas deben ser completamente automatizadas y ejecutables sin intervención manual.
 7.  **Colaboración:** Si encuentras ambigüedades en las ideas de prueba o necesitas aclaraciones sobre el comportamiento esperado, pregunta.
 8.  **Actualización de Código:** Si descubres bugs a través de estas pruebas, documenta el bug y, si es posible, crea una solución. Sin embargo, el enfoque principal es la creación de pruebas.
-
-¡Comienza a construir un conjunto de pruebas que nos dé total confianza en la aplicación!
+ ¡Comienza a construir un conjunto de pruebas que nos dé total confianza en la aplicación!
 
 ---
 
-## Plan de Resolución de Bugs Identificados (Actualización)
-
-Se han identificado dos bugs críticos que impiden el correcto funcionamiento y la visualización de resultados. La estrategia para su resolución se centrará en la creación de tests que reproduzcan el error, la implementación de soluciones robustas y la evaluación iterativa de los resultados.
+## Plan de Resolución de Bugs Identificados (Actualización) Se han identificado dos bugs críticos que impiden el correcto funcionamiento y la visualización de resultados. La estrategia para su resolución se centrará en la creación de tests que reproduzcan el error, la implementación de soluciones robustas y la evaluación iterativa de los resultados.
 
 ### Bug 1: `AttributeError: 'Dovela' object has no attribute 'y_base'`
 
@@ -170,9 +164,7 @@ Se han identificado dos bugs críticos que impiden el correcto funcionamiento y 
     *   Integrar estos tests en el conjunto de pruebas general y asegurar que no introducen regresiones.
     *   **Iteración:** Si se encuentran nuevos problemas, documentarlos y repetir el ciclo de test-solución-evaluación.
 
----
-
-**Instrucciones Generales para la Resolución de Bugs:**
+--- **Instrucciones Generales para la Resolución de Bugs:**
 *   **Priorización:** Abordar el Bug 1 (`AttributeError`) primero, ya que es un bloqueador para la visualización.
 *   **Desarrollo Dirigido por Pruebas (TDD):** Para cada bug, escribir los tests de reproducción *antes* de implementar la solución. Esto asegura que la solución realmente corrige el problema y que no se introducen regresiones.
 *   **Modularidad:** Mantener las soluciones lo más localizadas posible, afectando solo el código necesario.

--- a/core/geometry.py
+++ b/core/geometry.py
@@ -350,7 +350,7 @@ def crear_dovelas(circulo: CirculoFalla, perfil_terreno: List[Tuple[float, float
             print(f"DEBUG:   Llamando calcular_presion_poros(x_centro={x_centro:.2f}, altura={altura:.2f}, ...)")
             presion_poros = calcular_presion_poros(x_centro, altura, perfil_terreno, nivel_freatico)
             print(f"DEBUG:     Presión de poros calculada: {presion_poros:.2f}")
-            
+
             # Crear dovela
             dovela = Dovela(
                 x_centro=x_centro,
@@ -364,6 +364,10 @@ def crear_dovelas(circulo: CirculoFalla, perfil_terreno: List[Tuple[float, float
                 presion_poros=presion_poros,
                 longitud_arco=longitud_arco
             )
+            # Guardar elevaciones para compatibilidad con la GUI
+            y_superficie = interpolar_terreno(x_centro, perfil_terreno)
+            dovela.y_superficie = y_superficie
+            dovela.y_base = y_superficie - altura
             print(f"DEBUG:   Dovela {i} CREADA con éxito.")
             dovelas.append(dovela)
             

--- a/data/models.py
+++ b/data/models.py
@@ -86,6 +86,13 @@ class Dovela:
     longitud_arco: float  # ΔL en m
     fuerza_normal_efectiva: float = 0.0  # N' en kN
     tiene_traccion: bool = False
+    y_base: float = 0.0
+    y_superficie: float = 0.0
+
+    @property
+    def ancho_dovela(self) -> float:
+        """Alias para el ancho de la dovela."""
+        return self.ancho
     
     def __post_init__(self):
         """Validaciones básicas de geometría y parámetros."""

--- a/tests/test_bishop_dovela_attributes.py
+++ b/tests/test_bishop_dovela_attributes.py
@@ -1,0 +1,14 @@
+from core.bishop import bishop_talud_homogeneo
+
+
+def test_bishop_result_contains_dovela_heights():
+    res = bishop_talud_homogeneo(
+        altura=10.0,
+        angulo_talud=30.0,
+        cohesion=20.0,
+        phi_grados=25.0,
+        gamma=18.0,
+        num_dovelas=5,
+    )
+    dovela = res.dovelas[0]
+    assert hasattr(dovela, "y_base") and hasattr(dovela, "y_superficie")

--- a/tests/test_circle_constraints_regression.py
+++ b/tests/test_circle_constraints_regression.py
@@ -1,0 +1,15 @@
+from core.circle_constraints import CalculadorLimites, aplicar_limites_inteligentes
+from data.models import CirculoFalla
+
+
+def test_validar_y_corregir_no_unboundlocalerror():
+    perfil = [(0, 0), (10, 5), (20, 0)]
+    limites = aplicar_limites_inteligentes(perfil, "talud_empinado")
+    calc = CalculadorLimites()
+    circulo = CirculoFalla(xc=limites.centro_x_min + 1,
+                           yc=limites.centro_y_min + 1,
+                           radio=limites.radio_min + 1)
+    result = calc.validar_y_corregir_circulo(
+        circulo, limites, corregir_automaticamente=False
+    )
+    assert result.es_valido

--- a/tests/test_dovela_attributes.py
+++ b/tests/test_dovela_attributes.py
@@ -1,0 +1,14 @@
+import pytest
+from core.geometry import crear_dovelas, crear_perfil_simple
+from data.models import CirculoFalla, Estrato
+
+
+def test_dovelas_expose_base_and_surface_attributes():
+    perfil = crear_perfil_simple(0.0, 0.0, 10.0, 0.0, num_puntos=5)
+    estrato = Estrato(cohesion=10.0, phi_grados=30.0, gamma=18.0)
+    circulo = CirculoFalla(xc=5.0, yc=10.0, radio=12.0)
+    dovelas = crear_dovelas(circulo, perfil, estrato, num_dovelas=3)
+    d = dovelas[0]
+    assert hasattr(d, "y_base"), "y_base attribute missing"
+    assert hasattr(d, "y_superficie"), "y_superficie attribute missing"
+    assert d.y_superficie > d.y_base


### PR DESCRIPTION
## Summary
- add regression tests for missing `y_base`/`y_superficie` attributes
- expose dovela base and surface coordinates in model and creation function
- test circle validator execution when no automatic correction is used

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68411170e61083208c3562373db638f0