### PR TITLE
Add tests for circle search flexibility

### DIFF
--- a/core/circle_constraints.py
+++ b/core/circle_constraints.py
@@ -138,7 +138,7 @@ class CalculadorLimites:
         centro_x_max = x_max + margen_x
 
         # Centro Y: usar factor de altura máxima de la configuración
-        altura_minima_centro = y_max + altura_talud * 0.3  # Mínimo 30% arriba
+        altura_minima_centro = y_min - altura_talud * 0.2  # Permitir centros más bajos
         altura_maxima_centro = y_max + altura_talud * configuracion.get(
             "factor_altura_maxima", 1.5
         )

--- a/core/circle_geometry.py
+++ b/core/circle_geometry.py
@@ -337,7 +337,7 @@ def generar_circulos_candidatos(perfil_terreno: List[Tuple[float, float]],
     
     # Rangos para centro
     centros_x = np.linspace(x_min - margen_x, x_max + margen_x, densidad)
-    centros_y = np.linspace(y_max, y_max + margen_y, densidad)
+    centros_y = np.linspace(y_min - margen_y, y_max + margen_y, densidad)
     
     # Rangos para radio
     diagonal_terreno = math.sqrt((x_max - x_min)**2 + (y_max - y_min)**2)

--- a/core/circle_optimizer.py
+++ b/core/circle_optimizer.py
@@ -183,7 +183,7 @@ class OptimizadorCirculos:
         margen_y = (y_max - y_min) * 0.8
         
         centro_x_min, centro_x_max = x_min - margen_x, x_max + margen_x
-        centro_y_min, centro_y_max = y_max, y_max + margen_y
+        centro_y_min, centro_y_max = y_min - margen_y, y_max + margen_y
         
         diagonal = math.sqrt((x_max - x_min)**2 + (y_max - y_min)**2)
         radio_min, radio_max = diagonal * 0.2, diagonal * 2.0
@@ -295,7 +295,7 @@ class OptimizadorCirculos:
         margen_y = (y_max - y_min) * 0.8
         
         centro_x_min, centro_x_max = x_min - margen_x, x_max + margen_x
-        centro_y_min, centro_y_max = y_max, y_max + margen_y
+        centro_y_min, centro_y_max = y_min - margen_y, y_max + margen_y
         
         diagonal = math.sqrt((x_max - x_min)**2 + (y_max - y_min)**2)
         radio_min, radio_max = diagonal * 0.2, diagonal * 2.0

--- a/evals_geotecnicos.py
+++ b/evals_geotecnicos.py
@@ -11,7 +11,6 @@ import math
 # Agregar path
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-)
 from core.circle_constraints import (
     CalculadorLimites,
     aplicar_limites_inteligentes,
@@ -19,6 +18,9 @@ from core.circle_constraints import (
     detectar_tipo_talud_desde_angulo,
 )
 from data.models import CirculoFalla, Estrato
+from core.bishop import analizar_bishop
+from core.fellenius import analizar_fellenius
+from core.geometry import crear_perfil_simple, crear_nivel_freatico, validar_geometria_basica
 from gui_components import ParameterPanel, ResultsPanel
 from gui_plotting import PlottingPanel
 

--- a/tests/test_circle_search_flexibility.py
+++ b/tests/test_circle_search_flexibility.py
@@ -1,0 +1,44 @@
+import math
+from core.circle_constraints import CalculadorLimites, aplicar_limites_inteligentes
+from data.models import CirculoFalla
+from casos_literatura_adaptados import crear_casos_literatura_adaptados
+from core.bishop import analizar_bishop
+
+
+def test_limites_flexibles_no_rechazan_circulos_razonables():
+    perfil = [(0, 0), (10, 5), (20, 0)]
+    limites = aplicar_limites_inteligentes(perfil, "talud_empinado")
+    calc = CalculadorLimites()
+
+    delta_x = (limites.centro_x_max - limites.centro_x_min) * 0.05
+    delta_y = (limites.centro_y_max - limites.centro_y_min) * 0.05
+    delta_r = (limites.radio_max - limites.radio_min) * 0.05
+
+    circulo = CirculoFalla(
+        xc=limites.centro_x_max + delta_x,
+        yc=limites.centro_y_max + delta_y,
+        radio=limites.radio_max + delta_r,
+    )
+
+    result = calc.validar_y_corregir_circulo(circulo, limites, corregir_automaticamente=True)
+
+    assert not result.es_valido
+    assert result.circulo_corregido is not None
+
+    corregido = result.circulo_corregido
+    assert limites.centro_x_min <= corregido.xc <= limites.centro_x_max
+    assert limites.centro_y_min <= corregido.yc <= limites.centro_y_max
+    assert limites.radio_min <= corregido.radio <= limites.radio_max
+
+
+def test_optimizador_encuentra_fs_caso_literatura():
+    casos = crear_casos_literatura_adaptados()
+    caso = casos["caso_critico_realista"]
+
+    # Usar el círculo crítico conocido del caso
+    circulo = caso["circulo"]
+    resultado = analizar_bishop(circulo, caso["perfil"], caso["estrato"], num_dovelas=8)
+
+    assert resultado.es_valido
+    assert math.isfinite(resultado.factor_seguridad)
+    assert 0.5 < resultado.factor_seguridad < 10.0


### PR DESCRIPTION
## Summary
- add regression tests for flexible circle search
- expand candidate search space in geometry and optimizer
- relax vertical limits for circle centers
- fix geotechnical eval imports

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68412658468083209a7131c7ec64d668