### PR TITLE
Fix LIMPIAR button logic and add test

### DIFF
--- a/gui_app.py
+++ b/gui_app.py
@@ -476,6 +476,19 @@ class SlopeStabilityApp:
         """Actualizar mensaje de estado."""
         if hasattr(self, 'status_label'):
             self.status_label.configure(text=message)
+
+    def clear_results(self):
+        """Restablecer parámetros y limpiar resultados y gráficos."""
+        from gui_dialogs import AppUtils
+
+        # Limpiar resultados y gráficos utilizando utilidades existentes
+        AppUtils.clear_results(self)
+
+        # Restablecer parámetros de entrada si está disponible
+        if hasattr(self, 'parameter_panel') and hasattr(self.parameter_panel, 'reset_parameters'):
+            self.parameter_panel.reset_parameters()
+
+        self.update_status("Listo para análisis")
     
     def on_closing(self):
         """Manejar cierre de aplicación."""

--- a/gui_components.py
+++ b/gui_components.py
@@ -495,6 +495,29 @@ class ParameterPanel(ctk.CTkFrame):
             if self.callback:
                 self.callback("run_analysis")
 
+    def reset_parameters(self) -> None:
+        """Restablecer todos los campos de entrada a sus valores por defecto."""
+        # Valores por defecto
+        self.altura_var.set(8.0)
+        self.angulo_var.set(30.0)
+        self.cohesion_var.set(25.0)
+        self.phi_var.set(20.0)
+        self.gamma_var.set(18.0)
+        self.dovelas_var.set(10)
+        self.centro_x_var.set(0.0)
+        self.centro_y_var.set(15.0)
+        self.radio_var.set(12.0)
+        self.agua_var.set(False)
+        self.altura_nf_var.set(3.0)
+
+        # Restaurar elementos de interfaz
+        self.example_var.set("Manual (valores propios)")
+        self.case_description.configure(text="Ingrese sus propios valores")
+        self.load_geometry_btn.configure(text="🏔️ Cargar Geometría")
+        self.select_circle_btn.grid_remove()
+        self.toggle_water_controls(False)
+        self.update_sliders()
+
 
 class ResultsPanel(ctk.CTkFrame):
     """Panel de resultados del análisis."""

--- a/tests/test_gui_clear_button.py
+++ b/tests/test_gui_clear_button.py
@@ -1,0 +1,27 @@
+import os
+import pytest
+import customtkinter as ctk
+
+from gui_app import SlopeStabilityApp
+
+
+def test_clear_button_resets_state():
+    if os.environ.get("DISPLAY", "") == "":
+        pytest.skip("No display available for Tkinter")
+
+    app = SlopeStabilityApp()
+
+    # Cambiar algunos valores para simular uso
+    app.parameter_panel.altura_var.set(15.0)
+    app.results_panel.fs_bishop_label.configure(text="1.23")
+    app.plotting_panel.current_perfil = [(0, 0), (1, 1)]
+
+    # Ejecutar limpieza
+    app.clear_results()
+
+    # Verificaciones
+    assert app.parameter_panel.altura_var.get() == 8.0
+    assert app.results_panel.fs_bishop_label.cget("text") == "---"
+    assert app.plotting_panel.current_perfil is None
+
+    app.root.destroy()


### PR DESCRIPTION
## Summary
- implement `reset_parameters` method in ParameterPanel
- add `clear_results` method in SlopeStabilityApp using AppUtils
- create test verifying that the clear button resets parameters and plots

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy' etc.)*

------
https://chatgpt.com/codex/tasks/task_b_6841265f1e8483208333daff20479d99